### PR TITLE
Use Immutable collections and improve `Board` performance

### DIFF
--- a/lib/src/board.dart
+++ b/lib/src/board.dart
@@ -1,4 +1,6 @@
 import 'package:meta/meta.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import './square_set.dart';
 import './models.dart';
 import './attacks.dart';
@@ -26,33 +28,18 @@ class Board {
 
   /// Standard chess starting position.
   static const standard = Board(
-      occupied: SquareSet(0xffff00000000ffff),
-      promoted: SquareSet.empty,
-      sides: {
-        Side.white: SquareSet(0xffff),
-        Side.black: SquareSet(0xffff000000000000),
-      },
-      roles: {
-        Role.pawn: SquareSet(0x00ff00000000ff00),
-        Role.knight: SquareSet(0x4200000000000042),
-        Role.bishop: SquareSet(0x2400000000000024),
-        Role.rook: SquareSet.corners,
-        Role.queen: SquareSet(0x0800000000000008),
-        Role.king: SquareSet(0x1000000000000010),
-      });
+    occupied: SquareSet(0xffff00000000ffff),
+    promoted: SquareSet.empty,
+    sides: _standardSides,
+    roles: _standardRoles,
+  );
 
-  static const empty =
-      Board(occupied: SquareSet.empty, promoted: SquareSet.empty, sides: {
-    Side.white: SquareSet.empty,
-    Side.black: SquareSet.empty,
-  }, roles: {
-    Role.pawn: SquareSet.empty,
-    Role.knight: SquareSet.empty,
-    Role.bishop: SquareSet.empty,
-    Role.rook: SquareSet.empty,
-    Role.queen: SquareSet.empty,
-    Role.king: SquareSet.empty,
-  });
+  static const empty = Board(
+    occupied: SquareSet.empty,
+    promoted: SquareSet.empty,
+    sides: _emptySides,
+    roles: _emptyRoles,
+  );
 
   /// Parse the board part of a FEN string and returns a Board.
   ///
@@ -218,12 +205,12 @@ class Board {
     return removePieceAt(square)._copyWith(
       occupied: occupied.withSquare(square),
       promoted: piece.promoted ? promoted.withSquare(square) : null,
-      sides: {
+      sides: IMap({
         piece.color: sides[piece.color]!.withSquare(square),
-      },
-      roles: {
+      }),
+      roles: IMap({
         piece.role: roles[piece.role]!.withSquare(square),
-      },
+      }),
     );
   }
 
@@ -234,12 +221,12 @@ class Board {
         ? _copyWith(
             occupied: occupied.withoutSquare(square),
             promoted: piece.promoted ? promoted.withoutSquare(square) : null,
-            sides: {
+            sides: IMap({
               piece.color: sides[piece.color]!.withoutSquare(square),
-            },
-            roles: {
+            }),
+            roles: IMap({
               piece.role: roles[piece.role]!.withoutSquare(square),
-            },
+            }),
           )
         : this;
   }
@@ -257,12 +244,8 @@ class Board {
     return Board(
       occupied: occupied ?? this.occupied,
       promoted: promoted ?? this.promoted,
-      sides: sides != null
-          ? Map.unmodifiable({...this.sides, ...sides})
-          : this.sides,
-      roles: roles != null
-          ? Map.unmodifiable({...this.roles, ...roles})
-          : this.roles,
+      sides: sides != null ? this.sides.addAll(sides) : this.sides,
+      roles: roles != null ? this.roles.addAll(roles) : this.roles,
     );
   }
 
@@ -300,3 +283,31 @@ Piece? _charToPiece(String ch, bool promoted) {
   }
   return null;
 }
+
+const BySide<SquareSet> _standardSides = IMapConst({
+  Side.white: SquareSet(0xffff),
+  Side.black: SquareSet(0xffff000000000000),
+});
+
+const ByRole<SquareSet> _standardRoles = IMapConst({
+  Role.pawn: SquareSet(0x00ff00000000ff00),
+  Role.knight: SquareSet(0x4200000000000042),
+  Role.bishop: SquareSet(0x2400000000000024),
+  Role.rook: SquareSet.corners,
+  Role.queen: SquareSet(0x0800000000000008),
+  Role.king: SquareSet(0x1000000000000010),
+});
+
+const BySide<SquareSet> _emptySides = IMapConst({
+  Side.white: SquareSet.empty,
+  Side.black: SquareSet.empty,
+});
+
+const ByRole<SquareSet> _emptyRoles = IMapConst({
+  Role.pawn: SquareSet.empty,
+  Role.knight: SquareSet.empty,
+  Role.bishop: SquareSet.empty,
+  Role.rook: SquareSet.empty,
+  Role.queen: SquareSet.empty,
+  Role.king: SquareSet.empty,
+});

--- a/lib/src/board.dart
+++ b/lib/src/board.dart
@@ -205,15 +205,8 @@ class Board {
     return removePieceAt(square)._copyWith(
       occupied: occupied.withSquare(square),
       promoted: piece.promoted ? promoted.withSquare(square) : null,
-      sides: IMap.unsafe(
-        {
-          piece.color: sides[piece.color]!.withSquare(square),
-        },
-        config: const ConfigMap(),
-      ),
-      roles: IMap.unsafe({
-        piece.role: roles[piece.role]!.withSquare(square),
-      }, config: const ConfigMap()),
+      side: MapEntry(piece.color, sides[piece.color]!.withSquare(square)),
+      role: MapEntry(piece.role, roles[piece.role]!.withSquare(square)),
     );
   }
 
@@ -224,12 +217,10 @@ class Board {
         ? _copyWith(
             occupied: occupied.withoutSquare(square),
             promoted: piece.promoted ? promoted.withoutSquare(square) : null,
-            sides: IMap.unsafe({
-              piece.color: sides[piece.color]!.withoutSquare(square),
-            }, config: const ConfigMap()),
-            roles: IMap.unsafe({
-              piece.role: roles[piece.role]!.withoutSquare(square),
-            }, config: const ConfigMap()),
+            side: MapEntry(
+                piece.color, sides[piece.color]!.withoutSquare(square)),
+            role:
+                MapEntry(piece.role, roles[piece.role]!.withoutSquare(square)),
           )
         : this;
   }
@@ -241,14 +232,14 @@ class Board {
   Board _copyWith({
     SquareSet? occupied,
     SquareSet? promoted,
-    BySide<SquareSet>? sides,
-    ByRole<SquareSet>? roles,
+    MapEntry<Side, SquareSet>? side,
+    MapEntry<Role, SquareSet>? role,
   }) {
     return Board(
       occupied: occupied ?? this.occupied,
       promoted: promoted ?? this.promoted,
-      sides: sides != null ? this.sides.addAll(sides) : this.sides,
-      roles: roles != null ? this.roles.addAll(roles) : this.roles,
+      sides: side != null ? sides.addEntry(side) : sides,
+      roles: role != null ? roles.addEntry(role) : roles,
     );
   }
 

--- a/lib/src/board.dart
+++ b/lib/src/board.dart
@@ -205,12 +205,15 @@ class Board {
     return removePieceAt(square)._copyWith(
       occupied: occupied.withSquare(square),
       promoted: piece.promoted ? promoted.withSquare(square) : null,
-      sides: IMap({
-        piece.color: sides[piece.color]!.withSquare(square),
-      }),
-      roles: IMap({
+      sides: IMap.unsafe(
+        {
+          piece.color: sides[piece.color]!.withSquare(square),
+        },
+        config: const ConfigMap(),
+      ),
+      roles: IMap.unsafe({
         piece.role: roles[piece.role]!.withSquare(square),
-      }),
+      }, config: const ConfigMap()),
     );
   }
 
@@ -221,12 +224,12 @@ class Board {
         ? _copyWith(
             occupied: occupied.withoutSquare(square),
             promoted: piece.promoted ? promoted.withoutSquare(square) : null,
-            sides: IMap({
+            sides: IMap.unsafe({
               piece.color: sides[piece.color]!.withoutSquare(square),
-            }),
-            roles: IMap({
+            }, config: const ConfigMap()),
+            roles: IMap.unsafe({
               piece.role: roles[piece.role]!.withoutSquare(square),
-            }),
+            }, config: const ConfigMap()),
           )
         : this;
   }

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,4 +1,6 @@
 import 'package:meta/meta.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import './utils.dart';
 
 enum Side {
@@ -58,8 +60,8 @@ enum Role {
 /// See [SquareSet] to see how the mapping looks like.
 typedef Square = int;
 
-typedef BySide<T> = Map<Side, T>;
-typedef ByRole<T> = Map<Role, T>;
+typedef BySide<T> = IMap<Side, T>;
+typedef ByRole<T> = IMap<Role, T>;
 
 @immutable
 class Piece {

--- a/lib/src/position.dart
+++ b/lib/src/position.dart
@@ -1896,20 +1896,23 @@ class Castles {
     return unmovedRooks.has(square)
         ? _copyWith(
             unmovedRooks: unmovedRooks.withoutSquare(square),
-            rook: IMap.unsafe({
-              if (square <= 7)
-                Side.white: whiteRook.item1 == square
-                    ? whiteRook.withItem1(null)
-                    : whiteRook.item2 == square
-                        ? whiteRook.withItem2(null)
-                        : whiteRook,
-              if (square >= 56)
-                Side.black: blackRook.item1 == square
-                    ? blackRook.withItem1(null)
-                    : blackRook.item2 == square
-                        ? blackRook.withItem2(null)
-                        : blackRook,
-            }, config: const ConfigMap()),
+            rook: square <= 7
+                ? MapEntry(
+                    Side.white,
+                    whiteRook.item1 == square
+                        ? whiteRook.withItem1(null)
+                        : whiteRook.item2 == square
+                            ? whiteRook.withItem2(null)
+                            : whiteRook)
+                : square >= 56
+                    ? MapEntry(
+                        Side.black,
+                        blackRook.item1 == square
+                            ? blackRook.withItem1(null)
+                            : blackRook.item2 == square
+                                ? blackRook.withItem2(null)
+                                : blackRook)
+                    : null,
           )
         : this;
   }
@@ -1917,9 +1920,7 @@ class Castles {
   Castles discardSide(Side side) {
     return _copyWith(
       unmovedRooks: unmovedRooks.diff(SquareSet.backrankOf(side)),
-      rook: IMap.unsafe({
-        side: const Tuple2(null, null),
-      }, config: const ConfigMap()),
+      rook: MapEntry(side, const Tuple2(null, null)),
     );
   }
 
@@ -1933,28 +1934,28 @@ class Castles {
         .withoutSquare(rook);
     return _copyWith(
       unmovedRooks: unmovedRooks.withSquare(rook),
-      rook: IMap.unsafe({
-        side: cs == CastlingSide.queen
-            ? this.rook[side]!.withItem1(rook)
-            : this.rook[side]!.withItem2(rook),
-      }, config: const ConfigMap()),
-      path: IMap.unsafe({
-        side: cs == CastlingSide.queen
-            ? this.path[side]!.withItem1(path)
-            : this.path[side]!.withItem2(path),
-      }, config: const ConfigMap()),
+      rook: MapEntry(
+          side,
+          cs == CastlingSide.queen
+              ? this.rook[side]!.withItem1(rook)
+              : this.rook[side]!.withItem2(rook)),
+      path: MapEntry(
+          side,
+          cs == CastlingSide.queen
+              ? this.path[side]!.withItem1(path)
+              : this.path[side]!.withItem2(path)),
     );
   }
 
   Castles _copyWith({
     SquareSet? unmovedRooks,
-    BySide<Tuple2<Square?, Square?>>? rook,
-    BySide<Tuple2<SquareSet, SquareSet>>? path,
+    MapEntry<Side, Tuple2<Square?, Square?>>? rook,
+    MapEntry<Side, Tuple2<SquareSet, SquareSet>>? path,
   }) {
     return Castles(
       unmovedRooks: unmovedRooks ?? this.unmovedRooks,
-      rook: rook != null ? this.rook.addAll(rook) : this.rook,
-      path: path != null ? this.path.addAll(path) : this.path,
+      rook: rook != null ? this.rook.addEntry(rook) : this.rook,
+      path: path != null ? this.path.addEntry(path) : this.path,
     );
   }
 

--- a/lib/src/position.dart
+++ b/lib/src/position.dart
@@ -1896,7 +1896,7 @@ class Castles {
     return unmovedRooks.has(square)
         ? _copyWith(
             unmovedRooks: unmovedRooks.withoutSquare(square),
-            rook: IMap({
+            rook: IMap.unsafe({
               if (square <= 7)
                 Side.white: whiteRook.item1 == square
                     ? whiteRook.withItem1(null)
@@ -1909,7 +1909,7 @@ class Castles {
                     : blackRook.item2 == square
                         ? blackRook.withItem2(null)
                         : blackRook,
-            }),
+            }, config: const ConfigMap()),
           )
         : this;
   }
@@ -1917,9 +1917,9 @@ class Castles {
   Castles discardSide(Side side) {
     return _copyWith(
       unmovedRooks: unmovedRooks.diff(SquareSet.backrankOf(side)),
-      rook: IMap({
+      rook: IMap.unsafe({
         side: const Tuple2(null, null),
-      }),
+      }, config: const ConfigMap()),
     );
   }
 
@@ -1933,16 +1933,16 @@ class Castles {
         .withoutSquare(rook);
     return _copyWith(
       unmovedRooks: unmovedRooks.withSquare(rook),
-      rook: IMap({
+      rook: IMap.unsafe({
         side: cs == CastlingSide.queen
             ? this.rook[side]!.withItem1(rook)
             : this.rook[side]!.withItem2(rook),
-      }),
-      path: IMap({
+      }, config: const ConfigMap()),
+      path: IMap.unsafe({
         side: cs == CastlingSide.queen
             ? this.path[side]!.withItem1(path)
             : this.path[side]!.withItem2(path),
-      }),
+      }, config: const ConfigMap()),
     );
   }
 

--- a/lib/src/position.dart
+++ b/lib/src/position.dart
@@ -1,5 +1,7 @@
 import 'package:meta/meta.dart';
 import 'dart:math' as math;
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import './constants.dart';
 import './square_set.dart';
 import './attacks.dart';
@@ -191,10 +193,10 @@ abstract class Position<T extends Position<T>> {
   }
 
   /// Gets all the legal moves of this position.
-  Map<Square, SquareSet> get legalMoves {
+  IMap<Square, SquareSet> get legalMoves {
     final context = _makeContext();
-    if (context.isVariantEnd) return Map.unmodifiable({});
-    return Map.unmodifiable({
+    if (context.isVariantEnd) return IMap(const {});
+    return IMap({
       for (final s in board.bySide(turn).squares)
         s: _legalMovesOf(s, context: context)
     });
@@ -1847,22 +1849,14 @@ class Castles {
 
   static const standard = Castles(
     unmovedRooks: SquareSet.corners,
-    rook: {Side.white: Tuple2(0, 7), Side.black: Tuple2(56, 63)},
-    path: {
-      Side.white:
-          Tuple2(SquareSet(0x000000000000000e), SquareSet(0x0000000000000060)),
-      Side.black:
-          Tuple2(SquareSet(0x0e00000000000000), SquareSet(0x6000000000000000))
-    },
+    rook: _standardCastleRook,
+    path: _standardCastlePath,
   );
 
   static const empty = Castles(
     unmovedRooks: SquareSet.empty,
-    rook: {Side.white: Tuple2(null, null), Side.black: Tuple2(null, null)},
-    path: {
-      Side.white: Tuple2(SquareSet.empty, SquareSet.empty),
-      Side.black: Tuple2(SquareSet.empty, SquareSet.empty)
-    },
+    rook: _emptyCastleRook,
+    path: _emptyCastlePath,
   );
 
   factory Castles.fromSetup(Setup setup) {
@@ -1902,7 +1896,7 @@ class Castles {
     return unmovedRooks.has(square)
         ? _copyWith(
             unmovedRooks: unmovedRooks.withoutSquare(square),
-            rook: {
+            rook: IMap({
               if (square <= 7)
                 Side.white: whiteRook.item1 == square
                     ? whiteRook.withItem1(null)
@@ -1915,7 +1909,7 @@ class Castles {
                     : blackRook.item2 == square
                         ? blackRook.withItem2(null)
                         : blackRook,
-            },
+            }),
           )
         : this;
   }
@@ -1923,9 +1917,9 @@ class Castles {
   Castles discardSide(Side side) {
     return _copyWith(
       unmovedRooks: unmovedRooks.diff(SquareSet.backrankOf(side)),
-      rook: {
+      rook: IMap({
         side: const Tuple2(null, null),
-      },
+      }),
     );
   }
 
@@ -1939,16 +1933,16 @@ class Castles {
         .withoutSquare(rook);
     return _copyWith(
       unmovedRooks: unmovedRooks.withSquare(rook),
-      rook: {
+      rook: IMap({
         side: cs == CastlingSide.queen
             ? this.rook[side]!.withItem1(rook)
             : this.rook[side]!.withItem2(rook),
-      },
-      path: {
+      }),
+      path: IMap({
         side: cs == CastlingSide.queen
             ? this.path[side]!.withItem1(path)
             : this.path[side]!.withItem2(path),
-      },
+      }),
     );
   }
 
@@ -1959,16 +1953,14 @@ class Castles {
   }) {
     return Castles(
       unmovedRooks: unmovedRooks ?? this.unmovedRooks,
-      rook:
-          rook != null ? Map.unmodifiable({...this.rook, ...rook}) : this.rook,
-      path:
-          path != null ? Map.unmodifiable({...this.path, ...path}) : this.path,
+      rook: rook != null ? this.rook.addAll(rook) : this.rook,
+      path: path != null ? this.path.addAll(path) : this.path,
     );
   }
 
   @override
   String toString() =>
-      'Castles(unmovedRooks: $unmovedRooks, rook: $rook, path: $path)';
+      'Castles(unmovedRooks: $unmovedRooks, rook: ${rook.unlockView}, path: ${path.unlockView})';
 
   @override
   bool operator ==(Object other) =>
@@ -2083,3 +2075,21 @@ SquareSet _pseudoLegalMoves(Position pos, Square square, _Context context) {
     return pseudo;
   }
 }
+
+const BySide<Tuple2<Square?, Square?>> _standardCastleRook =
+    IMapConst({Side.white: Tuple2(0, 7), Side.black: Tuple2(56, 63)});
+
+const BySide<Tuple2<SquareSet, SquareSet>> _standardCastlePath = IMapConst({
+  Side.white:
+      Tuple2(SquareSet(0x000000000000000e), SquareSet(0x0000000000000060)),
+  Side.black:
+      Tuple2(SquareSet(0x0e00000000000000), SquareSet(0x6000000000000000))
+});
+
+const BySide<Tuple2<Square?, Square?>> _emptyCastleRook =
+    IMapConst({Side.white: Tuple2(null, null), Side.black: Tuple2(null, null)});
+
+const BySide<Tuple2<SquareSet, SquareSet>> _emptyCastlePath = IMapConst({
+  Side.white: Tuple2(SquareSet.empty, SquareSet.empty),
+  Side.black: Tuple2(SquareSet.empty, SquareSet.empty)
+});

--- a/lib/src/setup.dart
+++ b/lib/src/setup.dart
@@ -1,4 +1,6 @@
 import 'package:meta/meta.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import 'dart:math' as math;
 import './square_set.dart';
 import './models.dart';
@@ -216,24 +218,7 @@ class Pockets {
   final BySide<ByRole<int>> value;
 
   /// An empty pocket.
-  static const empty = Pockets(value: {
-    Side.white: {
-      Role.pawn: 0,
-      Role.knight: 0,
-      Role.bishop: 0,
-      Role.rook: 0,
-      Role.queen: 0,
-      Role.king: 0,
-    },
-    Side.black: {
-      Role.pawn: 0,
-      Role.knight: 0,
-      Role.bishop: 0,
-      Role.rook: 0,
-      Role.queen: 0,
-      Role.king: 0,
-    },
-  });
+  static const empty = Pockets(value: _emptyPocketsBySide);
 
   /// Gets the total number of pieces in the pocket.
   int get size => value.values
@@ -266,26 +251,14 @@ class Pockets {
 
   /// Increments the number of pieces in the pocket of that [Side] and [Role].
   Pockets increment(Side side, Role role) {
-    return Pockets(
-        value: Map.unmodifiable({
-      ...value,
-      side: {
-        ...value[side]!,
-        role: of(side, role) + 1,
-      },
-    }));
+    final newPocket = value[side]!.add(role, of(side, role) + 1);
+    return Pockets(value: value.add(side, newPocket));
   }
 
   /// Decrements the number of pieces in the pocket of that [Side] and [Role].
   Pockets decrement(Side side, Role role) {
-    return Pockets(
-        value: Map.unmodifiable({
-      ...value,
-      side: {
-        ...value[side]!,
-        role: of(side, role) - 1,
-      },
-    }));
+    final newPocket = value[side]!.add(role, of(side, role) - 1);
+    return Pockets(value: value.add(side, newPocket));
   }
 
   @override
@@ -439,3 +412,17 @@ int _nthIndexOf(String haystack, String needle, int nth) {
   }
   return index;
 }
+
+const ByRole<int> _emptyPocket = IMapConst({
+  Role.pawn: 0,
+  Role.knight: 0,
+  Role.bishop: 0,
+  Role.rook: 0,
+  Role.queen: 0,
+  Role.king: 0,
+});
+
+const BySide<ByRole<int>> _emptyPocketsBySide = IMapConst({
+  Side.white: _emptyPocket,
+  Side.black: _emptyPocket,
+});

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,3 +1,5 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import './models.dart';
 import './constants.dart';
 import './position.dart';
@@ -25,9 +27,9 @@ String toAlgebraic(Square square) =>
 /// Gets all the legal moves of this position in the algebraic coordinate notation.
 ///
 /// Includes both possible representations of castling moves (unless `chess960` is true).
-Map<String, Set<String>> algebraicLegalMoves(Position pos,
+IMap<String, ISet<String>> algebraicLegalMoves(Position pos,
     {bool isChess960 = false}) {
-  final Map<String, Set<String>> result = {};
+  final Map<String, ISet<String>> result = {};
   for (final entry in pos.legalMoves.entries) {
     final dests = entry.value.squares;
     if (dests.isNotEmpty) {
@@ -47,10 +49,10 @@ Map<String, Set<String>> algebraicLegalMoves(Position pos,
           destSet.add('g8');
         }
       }
-      result[toAlgebraic(from)] = Set.unmodifiable(destSet);
+      result[toAlgebraic(from)] = ISet(destSet);
     }
   }
-  return Map.unmodifiable(result);
+  return IMap(result);
 }
 
 /// Utility for nullable fields in copyWith methods

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
   sdk: '>=2.17.5 <3.0.0'
 
 dependencies:
+  fast_immutable_collections: ^9.0.0
   meta: ^1.8.0
 
 dev_dependencies:

--- a/test/board_test.dart
+++ b/test/board_test.dart
@@ -1,4 +1,6 @@
 import 'package:dartchess/dartchess.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import 'package:test/test.dart';
 
 void main() {
@@ -22,20 +24,20 @@ void main() {
     expect(board2.pieceAt(60), piece);
     expect(
         board2.sides,
-        equals({
-          Side.white: const SquareSet(0x100000000000FFFF),
-          Side.black: const SquareSet(0xEFFF000000000000)
-        }));
+        equals(IMap(const {
+          Side.white: SquareSet(0x100000000000FFFF),
+          Side.black: SquareSet(0xEFFF000000000000)
+        })));
     expect(
         board2.roles,
-        equals({
-          Role.pawn: const SquareSet(0x00FF00000000FF00),
-          Role.knight: const SquareSet(0x4200000000000042),
-          Role.bishop: const SquareSet(0x2400000000000024),
+        equals(IMap(const {
+          Role.pawn: SquareSet(0x00FF00000000FF00),
+          Role.knight: SquareSet(0x4200000000000042),
+          Role.bishop: SquareSet(0x2400000000000024),
           Role.rook: SquareSet.corners,
-          Role.queen: const SquareSet(0x0800000000000008),
-          Role.king: const SquareSet(0x1000000000000010)
-        }));
+          Role.queen: SquareSet(0x0800000000000008),
+          Role.king: SquareSet(0x1000000000000010)
+        })));
   });
 
   test('removePieceAt', () {

--- a/test/board_test.dart
+++ b/test/board_test.dart
@@ -22,12 +22,9 @@ void main() {
 
     final board2 = Board.standard.setPieceAt(60, piece);
     expect(board2.pieceAt(60), piece);
-    expect(
-        board2.sides,
-        equals(IMap(const {
-          Side.white: SquareSet(0x100000000000FFFF),
-          Side.black: SquareSet(0xEFFF000000000000)
-        })));
+    expect(board2.white, const SquareSet(0x100000000000FFFF));
+
+    expect(board2.black, const SquareSet(0xEFFF000000000000));
     expect(
         board2.roles,
         equals(IMap(const {

--- a/test/board_test.dart
+++ b/test/board_test.dart
@@ -25,16 +25,12 @@ void main() {
     expect(board2.white, const SquareSet(0x100000000000FFFF));
 
     expect(board2.black, const SquareSet(0xEFFF000000000000));
-    expect(
-        board2.roles,
-        equals(IMap(const {
-          Role.pawn: SquareSet(0x00FF00000000FF00),
-          Role.knight: SquareSet(0x4200000000000042),
-          Role.bishop: SquareSet(0x2400000000000024),
-          Role.rook: SquareSet.corners,
-          Role.queen: SquareSet(0x0800000000000008),
-          Role.king: SquareSet(0x1000000000000010)
-        })));
+    expect(board2.pawns, const SquareSet(0x00FF00000000FF00));
+    expect(board2.knights, const SquareSet(0x4200000000000042));
+    expect(board2.bishops, const SquareSet(0x2400000000000024));
+    expect(board2.rooks, SquareSet.corners);
+    expect(board2.queens, const SquareSet(0x0800000000000008));
+    expect(board2.kings, const SquareSet(0x1000000000000010));
   });
 
   test('removePieceAt', () {

--- a/test/board_test.dart
+++ b/test/board_test.dart
@@ -1,6 +1,4 @@
 import 'package:dartchess/dartchess.dart';
-import 'package:fast_immutable_collections/fast_immutable_collections.dart'
-    hide Tuple2;
 import 'package:test/test.dart';
 
 void main() {

--- a/test/position_test.dart
+++ b/test/position_test.dart
@@ -1,3 +1,5 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import 'package:dartchess/dartchess.dart';
 import 'package:test/test.dart';
 
@@ -44,17 +46,17 @@ void main() {
     test('discard side', () {
       expect(
           Castles.standard.discardSide(Side.white).rook,
-          equals({
-            Side.white: const Tuple2(null, null),
-            Side.black: const Tuple2(56, 63)
-          }));
+          equals(IMap(const {
+            Side.white: Tuple2(null, null),
+            Side.black: Tuple2(56, 63)
+          })));
 
       expect(
           Castles.standard.discardSide(Side.black).rook,
-          equals({
-            Side.white: const Tuple2(0, 7),
-            Side.black: const Tuple2(null, null)
-          }));
+          equals(IMap(const {
+            Side.white: Tuple2(0, 7),
+            Side.black: Tuple2(null, null)
+          })));
     });
   });
 
@@ -315,7 +317,7 @@ void main() {
     });
 
     test('standard position legal moves', () {
-      final moves = {
+      final moves = IMap({
         0: SquareSet.empty,
         1: const SquareSet.fromSquare(16).withSquare(18),
         2: SquareSet.empty,
@@ -332,7 +334,7 @@ void main() {
         13: const SquareSet.fromSquare(21).withSquare(29),
         14: const SquareSet.fromSquare(22).withSquare(30),
         15: const SquareSet.fromSquare(23).withSquare(31),
-      };
+      });
       expect(Chess.initial.legalMoves, equals(moves));
     });
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,3 +1,5 @@
+import 'package:fast_immutable_collections/fast_immutable_collections.dart'
+    hide Tuple2;
 import 'package:dartchess/dartchess.dart';
 import 'package:test/test.dart';
 
@@ -29,6 +31,6 @@ void main() {
     final pos = Chess.fromSetup(Setup.parseFen(
         'rk2r3/pppbnppp/3p2n1/P2Pp3/4P2q/R5NP/1PP2PP1/1KNQRB2 b Kkq - 0 1'));
     expect(algebraicLegalMoves(pos, isChess960: true)['b8'],
-        equals({'a8', 'c8', 'e8'}));
+        equals(ISet(const {'a8', 'c8', 'e8'})));
   });
 }


### PR DESCRIPTION
Benchmark with `Board` using standard mutable `Map`:
```
dart run benchmark
 DONE  ./benchmark/dartchess_benchmark.dart (129 s)
 ✓ make fen from initial position (50 us)
 ✓ make fen from random position (47 us)
 ✓ parse san moves (5 ms)
 ✓ parse san moves, play unchecked (5 ms)
 ✓ valid fen moves (64 us)
 ✓ algebraic legal moves (227 us)
 ✓ parsePgn - kasparov-deep-blue (2 ms)
 ✓ makePgn (307 us)
 ✓ perft (56 s)
```

Benchmark with `Board` using an `IMap`
```
dart run benchmark
 DONE  ./benchmark/dartchess_benchmark.dart (138 s)
 ✓ make fen from initial position (99 us)
 ✓ make fen from random position (61 us)
 ✓ parse san moves (5 ms)
 ✓ parse san moves, play unchecked (4 ms)
 ✓ valid fen moves (70 us)
 ✓ algebraic legal moves (266 us)
 ✓ parsePgn - kasparov-deep-blue (2 ms)
 ✓ makePgn (301 us)
 ✓ perft (59 s)
```

Benchmark with `Board` using only square sets (no `Map`):
```
dart run benchmark
 DONE  ./benchmark/dartchess_benchmark.dart (78 s)
 ✓ make fen from initial position (31 us)
 ✓ make fen from random position (24 us)
 ✓ parse san moves (1 ms)
 ✓ parse san moves, play unchecked (1 ms)
 ✓ valid fen moves (47 us)
 ✓ algebraic legal moves (238 us)
 ✓ parsePgn - kasparov-deep-blue (2 ms)
 ✓ makePgn (307 us)
 ✓ perft (29 s)
```