### PR TITLE
fix en passant bug for Crazyhouse and castling bug

### DIFF
--- a/lib/src/position.dart
+++ b/lib/src/position.dart
@@ -974,14 +974,15 @@ abstract class Position<T extends Position<T>> {
   ///
   /// Returns the [CastlingSide] or `null` if the move is a regular move.
   CastlingSide? _getCastlingSide(Move move) {
-    if (move is NormalMove) {
-      final delta = move.to - move.from;
-      if (delta.abs() != 2 && !board.bySide(turn).has(move.to)) {
-        return null;
-      }
-      if (!board.kings.has(move.from)) {
-        return null;
-      }
+    if (move is! NormalMove) return null;
+    if (turn == Side.white && move.to > 7) return null;
+    if (turn == Side.black && move.to < 56) return null;
+    if (!board.kings.has(move.from)) return null;
+    if (!board.bySide(turn).has(move.from)) return null;
+
+    final delta = move.to - move.from;
+    if (delta.abs() == 2 ||
+        (board.bySide(turn).has(move.to) && board.rooks.has(move.to))) {
       return delta > 0 ? CastlingSide.king : CastlingSide.queen;
     }
     return null;
@@ -1526,7 +1527,7 @@ class Crazyhouse extends Position<Crazyhouse> {
       pockets: pockets != null ? pockets.value : this.pockets,
       turn: turn ?? this.turn,
       castles: castles ?? this.castles,
-      epSquare: epSquare != null ? epSquare.value : this.epSquare,
+      epSquare: epSquare?.value,
       halfmoves: halfmoves ?? this.halfmoves,
       fullmoves: fullmoves ?? this.fullmoves,
     );


### PR DESCRIPTION
A pair of bugs I uncovered while investigating the Crazyhouse perft today.

### En Passant for Crazyhouse
The previous _copyWith() would carry the epSquare forward to the next move, which made this sequence possible: 

Black: Qg5
White: Nxg5
Black: f5 (creates epSquare at f6)
White: Q@f7 (copyWith() is given null for epSquare, which then copies f6 forward to Black) 
Black: gxf6 (captures the Queen on f7)

### Castling
The previous _getCastlingSide() created all sorts of "legal" castling moves. e.g. depending on the setup, I saw things like Ka2, Kd4, and Kf3 (moving onto his own pawn or knight) resulting in a kingside castle, and Ke1 (moving onto its own square) resulting in a queenside castle. In one position I had 13 legal moves that resulted in a castle. They all involved moving onto another friendly piece or e1.

The corrected version only allows 2 castling options for kingside and 2 options for queenside: moving the king two squares to the left or right OR moving the king onto the rook