### PR TITLE
Additional unit tests for attacks

### DIFF
--- a/test/attacks_test.dart
+++ b/test/attacks_test.dart
@@ -16,7 +16,7 @@ void main() {
     expect(kingAttacks(21), attacks);
   });
 
-  test('King attacks in near edges', () {
+  test('King attacks near edges', () {
     final attacks = makeSquareSet('''
 . . . . . . . .
 . . . . . . . .
@@ -114,7 +114,7 @@ void main() {
     expect(pawnAttacks(Side.black, 39), attacks);
   });
 
-  test('bishop attacks, empty board', () {
+  test('Bishop attacks, empty board', () {
     expect(bishopAttacks(27, SquareSet.empty), makeSquareSet('''
 . . . . . . . 1
 1 . . . . . 1 .
@@ -150,7 +150,30 @@ void main() {
 '''));
   });
 
-  test('rook attacks, empty board', () {
+  test('Bishop attacks, surrounded in occupied board', () {
+    final occupied = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . 1 1 1 . .
+. . . 1 . 1 . .
+. . . 1 1 1 . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+''');
+    expect(bishopAttacks(36, occupied), makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . 1 . 1 . .
+. . . . . . . .
+. . . 1 . 1 . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+'''));
+  });
+
+  test('Rook attacks, empty board', () {
     expect(rookAttacks(10, SquareSet.empty), makeSquareSet('''
 . . 1 . . . . .
 . . 1 . . . . .
@@ -163,7 +186,7 @@ void main() {
 '''));
   });
 
-  test('rook attacks, occupied board', () {
+  test('Rook attacks, occupied board', () {
     final occupied = makeSquareSet('''
 . . . . . . . .
 . . . . . . . .
@@ -186,7 +209,30 @@ void main() {
 '''));
   });
 
-  test('queen attacks, empty board', () {
+  test('Rook attacks, surrounded in occupied board', () {
+    final occupied = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . 1 1 1 . .
+. . . 1 . 1 . .
+. . . 1 1 1 . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+''');
+    expect(rookAttacks(36, occupied), makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . . 1 . . .
+. . . 1 . 1 . .
+. . . . 1 . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+'''));
+  });
+
+  test('Queen attacks, empty board', () {
     expect(queenAttacks(37, SquareSet.empty), makeSquareSet('''
 . . 1 . . 1 . .
 . . . 1 . 1 . 1
@@ -199,7 +245,7 @@ void main() {
 '''));
   });
 
-  test('queen attacks, occupied board', () {
+  test('Queen attacks, occupied board', () {
     final occupied = makeSquareSet('''
 . . . . . . . .
 . . . . . . . .
@@ -217,6 +263,29 @@ void main() {
 . 1 1 1 . . . .
 1 . . . 1 . . .
 . . . . . 1 . .
+. . . . . . . .
+. . . . . . . .
+'''));
+  });
+
+  test('Queen attacks, surrounded in occupied board', () {
+    final occupied = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . 1 1 1 . .
+. . . 1 . 1 . .
+. . . 1 1 1 . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+''');
+    expect(queenAttacks(36, occupied), makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . 1 1 1 . .
+. . . 1 . 1 . .
+. . . 1 1 1 . .
+. . . . . . . .
 . . . . . . . .
 . . . . . . . .
 '''));

--- a/test/attacks_test.dart
+++ b/test/attacks_test.dart
@@ -16,6 +16,20 @@ void main() {
     expect(kingAttacks(21), attacks);
   });
 
+  test('King attacks in near edges', () {
+    final attacks = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . 1 1
+. . . . . . 1 .
+''');
+    expect(kingAttacks(7), attacks);
+  });
+
   test('Knight attacks', () {
     final attacks = makeSquareSet('''
 . . . . . . . .
@@ -28,6 +42,20 @@ void main() {
 . . . . . . . .
 ''');
     expect(knightAttacks(35), attacks);
+  });
+
+  test('Knight attacks near edges', () {
+    final attacks = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . 1 . 1
+. . . . 1 . . .
+. . . . . . . .
+. . . . 1 . . .
+''');
+    expect(knightAttacks(14), attacks);
   });
 
   test('White pawn attacks', () {
@@ -44,6 +72,20 @@ void main() {
     expect(pawnAttacks(Side.white, 11), attacks);
   });
 
+  test('White pawn attacks near edges', () {
+    final attacks = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. 1 . . . . . .
+. . . . . . . .
+. . . . . . . .
+''');
+    expect(pawnAttacks(Side.white, 8), attacks);
+  });
+
   test('Black pawn attacks', () {
     final attacks = makeSquareSet('''
 . . . . . . . .
@@ -56,6 +98,20 @@ void main() {
 . . . . . . . .
 ''');
     expect(pawnAttacks(Side.black, 36), attacks);
+  });
+
+  test('Black pawn attacks near edges', () {
+    final attacks = makeSquareSet('''
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+. . . . . . 1 .
+. . . . . . . .
+. . . . . . . .
+. . . . . . . .
+''');
+    expect(pawnAttacks(Side.black, 39), attacks);
   });
 
   test('bishop attacks, empty board', () {

--- a/test/attacks_test.dart
+++ b/test/attacks_test.dart
@@ -290,4 +290,33 @@ void main() {
 . . . . . . . .
 '''));
   });
+
+  test('Legal board position asserts for attacks', () {
+    const illegalBoardPosition = 65;
+    const emptySquareSet = SquareSet.empty;
+
+    expect(() {
+      kingAttacks(illegalBoardPosition);
+    }, throwsA(isA<AssertionError>()));
+
+    expect(() {
+      pawnAttacks(Side.white, illegalBoardPosition);
+    }, throwsA(isA<AssertionError>()));
+
+    expect(() {
+      knightAttacks(illegalBoardPosition);
+    }, throwsA(isA<AssertionError>()));
+
+    expect(() {
+      bishopAttacks(illegalBoardPosition, emptySquareSet);
+    }, throwsA(isA<AssertionError>()));
+
+    expect(() {
+      rookAttacks(illegalBoardPosition, emptySquareSet);
+    }, throwsA(isA<AssertionError>()));
+
+    expect(() {
+      queenAttacks(illegalBoardPosition, emptySquareSet);
+    }, throwsA(isA<AssertionError>()));
+  });
 }


### PR DESCRIPTION
Adds few more unit tests to attacks. There were some cases which were not clearly covered with existing tests, so I added the following:

- Scenarios when a piece is near the edge of the board
- Scenarios when a piece is surrounded by other pieces
- Checks that none of the attack functions accepts illegal positions.

I wrote these as I was looking around the repo & seeing how things work. No errors where found, but you're welcome to add these to the current test battery.