### PR TITLE
Trim the fen before parsing it

### DIFF
--- a/lib/src/setup.dart
+++ b/lib/src/setup.dart
@@ -31,7 +31,7 @@ class Setup {
   ///
   /// Throws a [FenException] if the provided FEN is not valid.
   factory Setup.parseFen(String fen) {
-    final parts = fen.split(RegExp(r'[\s_]+'));
+    final parts = fen.trim().split(RegExp(r'[\s_]+'));
     if (parts.isEmpty) throw const FenException(IllegalFenCause.format);
 
     // board and pockets


### PR DESCRIPTION
I would trim the fen before parsing it. If someone copies and pastes a fen it's pretty common for it to have whitespace before or after. I think the mobile app already trims fens, but this would help anyone else using dartchess and prevent future issues in the mobile app.